### PR TITLE
Key import again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
  "hex",
  "rand_core",
  "rand_dev",
- "serde-wasm-bindgen",
+ "serde-wasm-bindgen 0.6.0",
  "serde_json",
  "wasm-bindgen",
 ]
@@ -397,6 +397,7 @@ version = "0.1.0"
 dependencies = [
  "dfns-key-import-common",
  "dfns-trusted-dealer-core",
+ "serde-wasm-bindgen 0.4.5",
  "serde_json",
  "wasm-bindgen",
 ]
@@ -1164,6 +1165,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "rand_dev",
  "serde",
  "serde_json",
+ "serde_with 1.14.0",
  "sha2",
 ]
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod encryption;
+pub mod types;
 pub mod version;
 
 extern crate alloc;

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,0 +1,23 @@
+//! Types used in key import and export functionalities
+
+/// The protocol for which a key can be used.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum KeyProtocol {
+    ///GG18
+    Gg18,
+    ///Binance EDDSA
+    BinanceEddsa,
+    ///CGGMP21
+    Cggmp21,
+}
+
+/// The curve for which a key can be used
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum KeyCurve {
+    /// Secp256k1 curve
+    Secp256k1,
+    /// Ed25519 curve
+    Ed25519,
+}

--- a/key-export-client/examples/export-request.rs
+++ b/key-export-client/examples/export-request.rs
@@ -1,8 +1,9 @@
 use dfns_key_export_client::KeyExportContext;
-use dfns_key_export_common::{
-    EncryptedShareAndIdentity, KeyCurve, KeyExportResponse, KeyProtocol, KeySharePlaintext,
+use dfns_key_export_common::{EncryptedShareAndIdentity, KeyExportResponse, KeySharePlaintext};
+use dfns_trusted_dealer_core::{
+    encryption,
+    types::{KeyCurve, KeyProtocol},
 };
-use dfns_trusted_dealer_core::encryption;
 use generic_ec::{NonZero, Point, SecretScalar};
 
 fn main() {

--- a/key-export-client/src/lib.rs
+++ b/key-export-client/src/lib.rs
@@ -25,10 +25,13 @@ use base64::{engine::general_purpose, Engine as _};
 use rand_core::{self, RngCore};
 
 use dfns_key_export_common::{
-    DecryptedShareAndIdentity, EncryptedShareAndIdentity, KeyCurve, KeyExportRequest,
-    KeyExportResponse, KeyProtocol, KeySharePlaintext, SupportedScheme,
+    DecryptedShareAndIdentity, EncryptedShareAndIdentity, KeyExportRequest, KeyExportResponse,
+    KeySharePlaintext, SupportedScheme,
 };
-use dfns_trusted_dealer_core::encryption::DecryptionKey;
+use dfns_trusted_dealer_core::{
+    encryption::DecryptionKey,
+    types::{KeyCurve, KeyProtocol},
+};
 use generic_ec::{curves::Secp256k1, Curve, NonZero, Point, Scalar, SecretScalar};
 
 const SUPPORTED_SCHEMES: [SupportedScheme; 1] = [SupportedScheme {

--- a/key-export-client/tests/tests.rs
+++ b/key-export-client/tests/tests.rs
@@ -1,8 +1,9 @@
 use dfns_key_export_client::{interpolate_secret_key, InterpolateKeyError, KeyExportContext};
-use dfns_key_export_common::{
-    EncryptedShareAndIdentity, KeyCurve, KeyExportResponse, KeySharePlaintext,
+use dfns_key_export_common::{EncryptedShareAndIdentity, KeyExportResponse, KeySharePlaintext};
+use dfns_trusted_dealer_core::{
+    encryption,
+    types::{KeyCurve, KeyProtocol},
 };
-use dfns_trusted_dealer_core::encryption;
 use generic_ec::{Curve, NonZero, Point, Scalar, SecretScalar};
 
 fn get_random_keys_and_shares<E: Curve>(
@@ -140,7 +141,7 @@ fn key_export_context() {
     let resp = KeyExportResponse {
         min_signers: 3,
         public_key: public_key.to_bytes(true).to_vec(),
-        protocol: dfns_key_export_common::KeyProtocol::Cggmp21,
+        protocol: KeyProtocol::Cggmp21,
         curve: KeyCurve::Secp256k1,
         encrypted_shares: encrypted_shares_and_ids.clone(),
     };
@@ -158,7 +159,7 @@ fn key_export_context() {
     let resp = KeyExportResponse {
         min_signers: 3,
         public_key: public_key.to_bytes(true).to_vec(),
-        protocol: dfns_key_export_common::KeyProtocol::Gg18,
+        protocol: KeyProtocol::Gg18,
         curve: KeyCurve::Secp256k1,
         encrypted_shares: encrypted_shares_and_ids.clone(),
     };
@@ -170,7 +171,7 @@ fn key_export_context() {
     let resp = KeyExportResponse {
         min_signers: 3,
         public_key: public_key.to_bytes(true).to_vec(),
-        protocol: dfns_key_export_common::KeyProtocol::Cggmp21,
+        protocol: KeyProtocol::Cggmp21,
         curve: KeyCurve::Secp256k1,
         encrypted_shares: encrypted_shares_and_ids,
     };

--- a/key-export-common/src/lib.rs
+++ b/key-export-common/src/lib.rs
@@ -7,6 +7,7 @@
 
 extern crate alloc;
 
+use dfns_trusted_dealer_core::types::{KeyCurve, KeyProtocol};
 pub use dfns_trusted_dealer_core::{encryption, version};
 
 use alloc::vec::Vec;
@@ -57,9 +58,9 @@ pub struct KeyExportResponse {
     /// The public key of the specified wallet.
     #[serde(with = "hex::serde")]
     pub public_key: Vec<u8>,
-    /// The protocol the exported scheme can be used for
+    /// The protocol the exported key can be used for
     pub protocol: KeyProtocol,
-    /// The curve the exported scheme can be used for
+    /// The curve the exported key can be used for
     pub curve: KeyCurve,
     /// Identities and encrypted shares of wallet's key holders.
     pub encrypted_shares: Vec<EncryptedShareAndIdentity>,
@@ -73,28 +74,6 @@ pub struct SupportedScheme {
     pub protocol: KeyProtocol,
     /// curve
     pub curve: KeyCurve,
-}
-
-/// The protocol for which a key can be used.
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum KeyProtocol {
-    ///GG18
-    Gg18,
-    ///Binance EDDSA
-    BinanceEddsa,
-    ///CGGMP21
-    Cggmp21,
-}
-
-/// The curve for which a key can be used
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum KeyCurve {
-    /// Secp256k1 curve
-    Secp256k1,
-    /// Ed25519 curve
-    Ed25519,
 }
 
 /// Identity and encrypted share of a signer.

--- a/key-import-client/Cargo.toml
+++ b/key-import-client/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2.84"
 serde_json = "1"
+serde-wasm-bindgen = "0.4"
 
 dfns-key-import-common = { path = "../key-import-common" }
 dfns-trusted-dealer-core = { path = "../core" }

--- a/key-import-client/src/lib.rs
+++ b/key-import-client/src/lib.rs
@@ -33,7 +33,7 @@ impl SignersInfo {
     /// Parses signers info from response obtained from Dfns API
     ///
     /// Throws `Error` if response is malformed
-    pub fn from_response(resp: &[u8]) -> Result<SignersInfo, JsError> {
+    pub fn new(resp: &[u8]) -> Result<SignersInfo, JsError> {
         let info = serde_json::from_slice(resp).context("couldn't parse the response")?;
         Ok(Self(info))
     }
@@ -48,6 +48,7 @@ impl SecretKey {
     /// Parses the secret key in big-endian format (the most widely-used format)
     ///
     /// Throws `Error` if secret key is invalid
+    #[wasm_bindgen(js_name = fromBytesBE)]
     pub fn from_bytes_be(bytes: &[u8]) -> Result<SecretKey, JsError> {
         let scalar = generic_ec::SecretScalar::from_be_bytes(bytes)
             .context("couldn't parse the secret key")?;
@@ -67,7 +68,7 @@ impl SecretKey {
 /// [Node JS crypto module]: https://nodejs.org/api/crypto.html
 ///
 /// Throws `Error` in case of failure
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = buildKeyImportRequest)]
 pub fn build_key_import_request(
     signers_info: &SignersInfo,
     secret_key: &SecretKey,

--- a/key-import-client/src/lib.rs
+++ b/key-import-client/src/lib.rs
@@ -11,6 +11,8 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
+use common::KeyImportRequest;
+use dfns_trusted_dealer_core::types::{KeyCurve, KeyProtocol};
 use wasm_bindgen::prelude::*;
 
 use dfns_key_import_common::{
@@ -102,15 +104,18 @@ pub fn build_key_import_request(
                 .encrypt(&mut rng, &[], &mut key_share)?;
             Ok(common::KeyShareCiphertext {
                 encrypted_key_share: key_share,
-                recipient_identity: recipient.identity.clone(),
+                signer_id: recipient.signer_id.clone(),
             })
         })
         .collect::<Result<Vec<_>, dfns_trusted_dealer_core::encryption::Error>>()
         .map_err(|_| JsError::new("couldn't encrypt a key share"))?;
 
     // Build a request and serialize it
-    let req = common::KeyImportRequest {
-        key_shares_list: encrypted_key_shares,
+    let req = KeyImportRequest {
+        min_signers: 3,
+        protocol: KeyProtocol::Cggmp21,
+        curve: KeyCurve::Secp256k1,
+        encrypted_key_shares,
     };
     serde_json::to_vec(&req).context("serialize a request")
 }

--- a/key-import-client/src/lib.rs
+++ b/key-import-client/src/lib.rs
@@ -71,7 +71,7 @@ impl SecretKey {
 pub fn build_key_import_request(
     signers_info: &SignersInfo,
     secret_key: &SecretKey,
-) -> Result<Vec<u8>, JsError> {
+) -> Result<JsValue, JsError> {
     let mut rng = rand_core::OsRng;
 
     {
@@ -117,7 +117,8 @@ pub fn build_key_import_request(
         curve: KeyCurve::Secp256k1,
         encrypted_key_shares,
     };
-    serde_json::to_vec(&req).context("serialize a request")
+
+    serde_wasm_bindgen::to_value(&req).context("cannot serialize key-import request")
 }
 
 trait Context<T, E> {

--- a/key-import-client/src/lib.rs
+++ b/key-import-client/src/lib.rs
@@ -33,8 +33,8 @@ impl SignersInfo {
     /// Parses signers info from response obtained from Dfns API
     ///
     /// Throws `Error` if response is malformed
-    pub fn new(resp: &[u8]) -> Result<SignersInfo, JsError> {
-        let info = serde_json::from_slice(resp).context("couldn't parse the response")?;
+    pub fn new(resp: JsValue) -> Result<SignersInfo, JsError> {
+        let info = serde_wasm_bindgen::from_value(resp).context("couldn't parse the response")?;
         Ok(Self(info))
     }
 }

--- a/key-import-common/Cargo.toml
+++ b/key-import-common/Cargo.toml
@@ -13,6 +13,7 @@ generic-ec-zkp = { git = "https://github.com/dfns-labs/generic-ec", branch = "m"
 
 rand_core = { version = "0.6", default-features = false }
 serde = "1"
+serde_with = { version = "1", features = ["base64"] }
 hex = { version = "0.4", default-features = false, features = ["alloc", "serde"]}
 
 aes-gcm = "0.10"

--- a/key-import-common/src/lib.rs
+++ b/key-import-common/src/lib.rs
@@ -94,6 +94,7 @@ impl std::error::Error for Error {}
 ///
 /// Lists all the signers: their identity and encryption keys. List is sorted by signers identities.
 #[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(transparent)]
 pub struct SignersInfo {
     // This list must be sorted by `identity`
     signers: Vec<SignerInfo>,
@@ -167,11 +168,19 @@ mod tests {
     #[test]
     fn serialize_deserialize_signers_info() {
         let mut rng = rand_dev::DevRng::new();
+
+        // SignerInfo
+        let signer_info = SignerInfo {
+            encryption_key: encryption::DecryptionKey::generate(&mut rng).encryption_key(),
+            identity: Vec::new(),
+        };
+        let signer_ser = serde_json::to_vec(&signer_info).unwrap();
+        let signer_deser: SignerInfo = serde_json::from_slice(&signer_ser).unwrap();
+        assert_eq!(signer_info, signer_deser);
+
+        // SignersInfo
         let signers = SignersInfo {
-            signers: Vec::from([SignerInfo {
-                encryption_key: encryption::DecryptionKey::generate(&mut rng).encryption_key(),
-                identity: Vec::new(),
-            }]),
+            signers: Vec::from([signer_info]),
         };
         let signers_ser = serde_json::to_vec(&signers).unwrap();
         let signers_deser: SignersInfo = serde_json::from_slice(&signers_ser).unwrap();

--- a/key-import-common/src/lib.rs
+++ b/key-import-common/src/lib.rs
@@ -12,6 +12,7 @@ pub use dfns_trusted_dealer_core::encryption;
 pub use {generic_ec, generic_ec::curves::Secp256k1, rand_core};
 
 use alloc::vec::Vec;
+use serde_with::{base64::Base64, serde_as};
 
 use generic_ec::{Curve, Point, Scalar, SecretScalar};
 use rand_core::{CryptoRng, RngCore};
@@ -125,12 +126,13 @@ impl<'de> serde::Deserialize<'de> for SignersInfo {
 }
 
 /// Signer info
+#[serde_as]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct SignerInfo {
     /// Signer public encryption key
     pub encryption_key: encryption::EncryptionKey,
     /// Signer identity
-    #[serde(with = "hex::serde")]
+    #[serde_as(as = "Base64")]
     pub identity: Vec<u8>,
 }
 
@@ -144,12 +146,13 @@ pub struct KeyImportRequest {
 /// Encrypted key share
 ///
 /// Contains key share ciphertext and destination signer identity.
+#[serde_as]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct KeyShareCiphertext {
     /// Key share ciphertext
-    #[serde(with = "hex::serde")]
+    #[serde_as(as = "Base64")]
     pub encrypted_key_share: Vec<u8>,
     /// Identity of signer that's supposed to receive that key share
-    #[serde(with = "hex::serde")]
+    #[serde_as(as = "Base64")]
     pub recipient_identity: Vec<u8>,
 }

--- a/key-import-common/src/lib.rs
+++ b/key-import-common/src/lib.rs
@@ -12,6 +12,7 @@ pub use dfns_trusted_dealer_core::encryption;
 pub use {generic_ec, generic_ec::curves::Secp256k1, rand_core};
 
 use alloc::vec::Vec;
+use dfns_trusted_dealer_core::types::{KeyCurve, KeyProtocol};
 use serde_with::{base64::Base64, serde_as};
 
 use generic_ec::{Curve, Point, Scalar, SecretScalar};
@@ -111,7 +112,7 @@ impl SignersInfo {
 
 impl From<Vec<SignerInfo>> for SignersInfo {
     fn from(mut signers: Vec<SignerInfo>) -> Self {
-        signers.sort_unstable_by(|s1, s2| s1.identity.cmp(&s2.identity));
+        signers.sort_unstable_by(|s1, s2| s1.signer_id.cmp(&s2.signer_id));
         Self { signers }
     }
 }
@@ -134,14 +135,20 @@ pub struct SignerInfo {
     pub encryption_key: encryption::EncryptionKey,
     /// Signer identity
     #[serde_as(as = "Base64")]
-    pub identity: Vec<u8>,
+    pub signer_id: Vec<u8>,
 }
 
 /// Key import request that's intended to be sent to Dfns API
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct KeyImportRequest {
+    /// The threshold of the specified wallet.
+    pub min_signers: u32,
+    /// The protocol the imported key will be used for
+    pub protocol: KeyProtocol,
+    /// The curve the imported key will be used for
+    pub curve: KeyCurve,
     /// List of encrypted key shares per signer
-    pub key_shares_list: Vec<KeyShareCiphertext>,
+    pub encrypted_key_shares: Vec<KeyShareCiphertext>,
 }
 
 /// Encrypted key share
@@ -155,7 +162,7 @@ pub struct KeyShareCiphertext {
     pub encrypted_key_share: Vec<u8>,
     /// Identity of signer that's supposed to receive that key share
     #[serde_as(as = "Base64")]
-    pub recipient_identity: Vec<u8>,
+    pub signer_id: Vec<u8>,
 }
 
 #[cfg(test)]
@@ -172,7 +179,7 @@ mod tests {
         // SignerInfo
         let signer_info = SignerInfo {
             encryption_key: encryption::DecryptionKey::generate(&mut rng).encryption_key(),
-            identity: Vec::new(),
+            signer_id: Vec::new(),
         };
         let signer_ser = serde_json::to_vec(&signer_info).unwrap();
         let signer_deser: SignerInfo = serde_json::from_slice(&signer_ser).unwrap();

--- a/key-import-common/src/lib.rs
+++ b/key-import-common/src/lib.rs
@@ -95,7 +95,7 @@ impl std::error::Error for Error {}
 ///
 /// Lists all the signers: their identity and encryption keys. List is sorted by signers identities.
 #[derive(Debug, PartialEq, serde::Serialize)]
-#[serde(transparent)]
+#[serde(transparent, rename_all = "camelCase")]
 pub struct SignersInfo {
     // This list must be sorted by `identity`
     signers: Vec<SignerInfo>,
@@ -130,6 +130,7 @@ impl<'de> serde::Deserialize<'de> for SignersInfo {
 /// Signer info
 #[serde_as]
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SignerInfo {
     /// Signer public encryption key
     pub encryption_key: encryption::EncryptionKey,
@@ -140,6 +141,7 @@ pub struct SignerInfo {
 
 /// Key import request that's intended to be sent to Dfns API
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KeyImportRequest {
     /// The threshold of the specified wallet.
     pub min_signers: u32,
@@ -156,6 +158,7 @@ pub struct KeyImportRequest {
 /// Contains key share ciphertext and destination signer identity.
 #[serde_as]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KeyShareCiphertext {
     /// Key share ciphertext
     #[serde_as(as = "Base64")]


### PR DESCRIPTION
Implemented the latest updates from the engineering doc.
Mainly, serialize some fields as base 64 instead of hex, added some fields to KeyImportRequest, use camelCase in methods exposed to WASM and or serializing the structs returned from WASM.