### PR TITLE
Two changes on key export/import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,7 @@ base64 = "0.21"
 aes-gcm = "0.10"
 hkdf = "0.12"
 sha2 = "0.10"
-wasm-bindgen = "0.2.84"
+wasm-bindgen = { version = "0.2", optional = true}
 
 [dev-dependencies]
 rand_dev = "0.1"
@@ -21,3 +21,4 @@ serde_json = "1"
 
 [features]
 std = []
+wasm = ["dep:wasm-bindgen"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ base64 = "0.21"
 aes-gcm = "0.10"
 hkdf = "0.12"
 sha2 = "0.10"
+wasm-bindgen = "0.2.84"
 
 [dev-dependencies]
 rand_dev = "0.1"

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,11 +1,9 @@
 //! Types used in key import and export functionalities
 
-use wasm_bindgen::prelude::*;
-
 /// The protocol for which a key can be used.
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 pub enum KeyProtocol {
     ///GG18
     Gg18,
@@ -18,7 +16,7 @@ pub enum KeyProtocol {
 /// The curve for which a key can be used
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 pub enum KeyCurve {
     /// Secp256k1 curve
     Secp256k1,

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,8 +1,11 @@
 //! Types used in key import and export functionalities
 
+use wasm_bindgen::prelude::*;
+
 /// The protocol for which a key can be used.
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[wasm_bindgen]
 pub enum KeyProtocol {
     ///GG18
     Gg18,
@@ -15,6 +18,7 @@ pub enum KeyProtocol {
 /// The curve for which a key can be used
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[wasm_bindgen]
 pub enum KeyCurve {
     /// Secp256k1 curve
     Secp256k1,

--- a/key-export-common/Cargo.toml
+++ b/key-export-common/Cargo.toml
@@ -17,3 +17,6 @@ generic-ec-zkp = { git = "https://github.com/dfns-labs/generic-ec", branch = "m"
 
 [dev-dependencies]
 rand_dev = "0.1"
+
+[features]
+std = ["dfns-trusted-dealer-core/std"]

--- a/key-import-client/Cargo.toml
+++ b/key-import-client/Cargo.toml
@@ -13,4 +13,4 @@ serde_json = "1"
 serde-wasm-bindgen = "0.4"
 
 dfns-key-import-common = { path = "../key-import-common" }
-dfns-trusted-dealer-core = { path = "../core" }
+dfns-trusted-dealer-core = { path = "../core", features = [ "wasm" ]}


### PR DESCRIPTION
Included in the PR:
- Added feature "std" to dfns-key-export-common so it can be passed to reexported crate dfns-trusted-dealer-core.
- Added `min_singers`, `protocol`, `curve` as input parameteres to build_key_import_request(). 

For the second, I added `wasm-bindgen` as dependency to the `dfns-trusted-dealer-core` crate. @survived not sure if this is the best option, but I wanted to avoid code duplication.
