### PR TITLE
Reexport mod `types` of `dfns-trusted-delaer-core` in `dfns-key-export-common'

### DIFF
--- a/key-export-common/src/lib.rs
+++ b/key-export-common/src/lib.rs
@@ -8,7 +8,7 @@
 extern crate alloc;
 
 use dfns_trusted_dealer_core::types::{KeyCurve, KeyProtocol};
-pub use dfns_trusted_dealer_core::{encryption, version, types};
+pub use dfns_trusted_dealer_core::{encryption, types, version};
 
 use alloc::vec::Vec;
 use serde_with::{base64::Base64, serde_as};

--- a/key-export-common/src/lib.rs
+++ b/key-export-common/src/lib.rs
@@ -8,7 +8,7 @@
 extern crate alloc;
 
 use dfns_trusted_dealer_core::types::{KeyCurve, KeyProtocol};
-pub use dfns_trusted_dealer_core::{encryption, version};
+pub use dfns_trusted_dealer_core::{encryption, version, types};
 
 use alloc::vec::Vec;
 use serde_with::{base64::Base64, serde_as};


### PR DESCRIPTION
so that the test in `signers` that uses them can access them without importing `dfns-trusted-delaer-core`.