### PR TITLE
Fix EdDSA key import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "dfns-key-export"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.21.4",
  "dfns-trusted-dealer-common",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "dfns-key-import"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dfns-trusted-dealer-common",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
  "group",
  "platforms",
@@ -289,11 +290,13 @@ name = "dfns-key-import"
 version = "0.1.0"
 dependencies = [
  "dfns-trusted-dealer-common",
+ "ed25519-dalek",
  "generic-ec-zkp",
  "getrandom",
  "key-share",
  "rand_dev",
  "serde_json",
+ "sha2",
  "test-case",
  "zeroize",
 ]
@@ -337,6 +340,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.26",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "subtle",
 ]
 
 [[package]]
@@ -925,6 +949,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 
 [[package]]
 name = "stark-curve"

--- a/key-export/Cargo.toml
+++ b/key-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfns-key-export"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/key-export/tests/tests.rs
+++ b/key-export/tests/tests.rs
@@ -62,7 +62,7 @@ fn key_export_inner<E: Curve>(protocol: KeyProtocol, curve: KeyCurve) {
 
     // Recover secret key
     let recovered_secret_key = ctx
-        .recover_secret_key(resp_json)
+        .recover_secret_scalar(resp_json)
         .expect("this call should not return error");
     let recovered_secret_key = Scalar::from_be_bytes(recovered_secret_key.to_bytes_be()).unwrap();
     assert_eq!(public_key, Point::generator() * recovered_secret_key);
@@ -73,7 +73,7 @@ fn key_export_inner<E: Curve>(protocol: KeyProtocol, curve: KeyCurve) {
         ..resp
     };
     let resp = JsonValue::new(resp).unwrap();
-    let recovered_secret_key = ctx.recover_secret_key(resp);
+    let recovered_secret_key = ctx.recover_secret_scalar(resp);
     assert!(recovered_secret_key.is_err());
 }
 
@@ -104,7 +104,7 @@ fn exporting_unsupported_scheme_returns_error() {
         ..resp
     };
     let resp = JsonValue::new(resp).unwrap();
-    let recovered_secret_key = ctx.recover_secret_key(resp);
+    let recovered_secret_key = ctx.recover_secret_scalar(resp);
     assert!(recovered_secret_key.is_err());
 }
 

--- a/key-import/Cargo.toml
+++ b/key-import/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfns-key-import"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/key-import/Cargo.toml
+++ b/key-import/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1"
 common = { package = "dfns-trusted-dealer-common", path = "../common", features = ["import"] }
 
 generic-ec-zkp = { version = "0.2", default-features = false, features = ["serde", "alloc"] }
+sha2 = { version = "0.10", default-features = false }
 
 zeroize = { version = "1.7", default-features = false, features = ["alloc"]}
 
@@ -27,3 +28,5 @@ getrandom = { version = "0.2", features = ["js"] }
 rand_dev = "0.1"
 test-case = "3" 
 key-share = { version = "0.2", features = ["spof"] }
+
+ed25519 = { package = "ed25519-dalek", version = "2", default-features = false, features = ["hazmat"] }

--- a/key-import/src/lib.rs
+++ b/key-import/src/lib.rs
@@ -63,8 +63,12 @@ impl SecretScalar {
             be_bytes: bytes.into(),
         }
     }
+}
 
+impl SecretScalar {
     /// Returns bytes representation of the secret key in big-endian format
+    ///
+    /// It is not exposed in WASM API
     pub fn to_be_bytes(self) -> zeroize::Zeroizing<Vec<u8>> {
         self.be_bytes
     }

--- a/key-import/src/lib.rs
+++ b/key-import/src/lib.rs
@@ -48,7 +48,12 @@ impl SignersInfo {
     }
 }
 
-/// Secret key to be imported
+/// Secret key (represented by a scalar) to be imported
+///
+/// Our library only works with secret keys represented by a scalar. It's the case for ECDSA
+/// and Schnorr signing schemes. However, it is not the case for EdDSA. If you need to import
+/// an EdDSA secret key, you first need to convert it into the scalar by using
+/// [`convert_eddsa_secret_key_to_scalar`] function.
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub struct SecretScalar {
     be_bytes: zeroize::Zeroizing<Vec<u8>>,


### PR DESCRIPTION
* Rename `SecretKey` into `SecretScalar` to remove confusion
   Our library exclusively works on importing/exporting secret keys represented by scalars. It's the case for ECDSA and Schnorr signing schemes. However, it is not the case for EdDSA.
* Provide `key_import::convert_eddsa_secret_key_to_scalar` function that takes EdDSA secret key and converts it to secret scalar, so it's usable for key import