### PR TITLE
Rename cggmp21 to 24 in public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "dfns-key-export"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.21.7",
  "dfns-trusted-dealer-common",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "dfns-key-import"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "dfns-trusted-dealer-common",
  "ed25519-dalek",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "dfns-trusted-dealer-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "base64 0.21.7",

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.4.0
+* Rename `types::KeyProtocol::Cggmp21` to `Cggmp24` for consistency [#22]
+
+[#22]: https://github.com/dfns/trusted-dealer/pull/22
+
 ## v0.3.0
 * Add support of HD wallets [#21]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfns-trusted-dealer-common"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -13,7 +13,8 @@ pub enum KeyProtocol {
     /// Binance EDDSA
     BinanceEddsa,
     /// CGGMP21
-    Cggmp21,
+    #[serde(alias = "CGGMP21")]
+    Cggmp24,
     /// KU23
     Ku23,
     /// FROST

--- a/key-export/CHANGELOG.md
+++ b/key-export/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.4.0
+* Rename `KeyProtocol::Cggmp21` to `Cggmp24` for consistency [#22]
+
+[#22]: https://github.com/dfns/trusted-dealer/pull/22
+
 ## v0.3.0
 * Add support of HD wallets [#21]
 

--- a/key-export/Cargo.toml
+++ b/key-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfns-key-export"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 
@@ -12,7 +12,7 @@ description = "Cryptography code for exporting a key from Dfns"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-common = { package = "dfns-trusted-dealer-common", version = "0.3", path = "../common", features = ["export"] }
+common = { package = "dfns-trusted-dealer-common", version = "0.4", path = "../common", features = ["export"] }
 generic-ec = { version = "0.4", default-features = false, features = ["serde", "curve-secp256k1", "curve-stark", "curve-ed25519"] }
 generic-ec-zkp = { version = "0.4", default-features = false, features = ["serde", "alloc"] }
 zeroize = { version = "1.7", default-features = false, features = ["alloc"]}

--- a/key-export/examples/export-request.rs
+++ b/key-export/examples/export-request.rs
@@ -47,7 +47,7 @@ fn print_export_response() {
     let resp = dfns_key_export::types::KeyExportResponse {
         min_signers: 3,
         public_key: Point::<E>::zero().to_bytes(true).to_vec(),
-        protocol: KeyProtocol::Cggmp21,
+        protocol: KeyProtocol::Cggmp24,
         curve: KeyCurve::Secp256k1,
         encrypted_shares: encrypted_shares_and_ids,
     };

--- a/key-export/src/lib.rs
+++ b/key-export/src/lib.rs
@@ -35,11 +35,11 @@ use common::wasm_bindgen::{self, prelude::wasm_bindgen};
 
 const SUPPORTED_SCHEMES: [types::SupportedScheme; 6] = [
     types::SupportedScheme {
-        protocol: KeyProtocol::Cggmp21,
+        protocol: KeyProtocol::Cggmp24,
         curve: KeyCurve::Secp256k1,
     },
     types::SupportedScheme {
-        protocol: KeyProtocol::Cggmp21,
+        protocol: KeyProtocol::Cggmp24,
         curve: KeyCurve::Stark,
     },
     types::SupportedScheme {
@@ -159,7 +159,7 @@ impl KeyExportContext {
         // perform the interpolation, and return the private key.
         let (secret_scalar, chain_code) = match (response.protocol, response.curve) {
             (
-                KeyProtocol::Cggmp21 | KeyProtocol::Ku23 | KeyProtocol::FrostBitcoin,
+                KeyProtocol::Cggmp24 | KeyProtocol::Ku23 | KeyProtocol::FrostBitcoin,
                 KeyCurve::Secp256k1,
             ) => {
                 let key_shares = parse_key_shares(&decrypted_key_shares_and_ids)?;
@@ -174,7 +174,7 @@ impl KeyExportContext {
                         .into();
                 (secret_scalar, chain_code)
             }
-            (KeyProtocol::Cggmp21 | KeyProtocol::Ku23, KeyCurve::Stark) => {
+            (KeyProtocol::Cggmp24 | KeyProtocol::Ku23, KeyCurve::Stark) => {
                 let key_shares = parse_key_shares(&decrypted_key_shares_and_ids)?;
                 let public_key = parse_public_key(&response.public_key)?;
                 let chain_code = extract_chain_code(&key_shares)?;

--- a/key-export/tests/tests.rs
+++ b/key-export/tests/tests.rs
@@ -34,8 +34,8 @@ fn random_key<E: Curve>(
     (*public_key, key_shares)
 }
 
-#[test_case::case(KeyProtocol::Cggmp21, KeyCurve::Secp256k1; "cggmp21_secp256k1")]
-#[test_case::case(KeyProtocol::Cggmp21, KeyCurve::Stark; "cggmp21_stark")]
+#[test_case::case(KeyProtocol::Cggmp24, KeyCurve::Secp256k1; "cggmp21_secp256k1")]
+#[test_case::case(KeyProtocol::Cggmp24, KeyCurve::Stark; "cggmp21_stark")]
 #[test_case::case(KeyProtocol::Frost, KeyCurve::Ed25519; "frost_ed25519")]
 #[test_case::case(KeyProtocol::FrostBitcoin, KeyCurve::Secp256k1; "frost_bitcoin")]
 fn key_export(protocol: KeyProtocol, curve: KeyCurve) {
@@ -86,7 +86,7 @@ fn key_export_inner<E: Curve>(protocol: KeyProtocol, curve: KeyCurve) {
 
 #[test]
 fn exporting_unsupported_scheme_returns_error() {
-    let protocol = KeyProtocol::Cggmp21;
+    let protocol = KeyProtocol::Cggmp24;
     let curve = KeyCurve::Secp256k1;
     type E = generic_ec::curves::Secp256k1;
 

--- a/key-import/CHANGELOG.md
+++ b/key-import/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.4.0
+* Rename `KeyProtocol::Cggmp21` to `Cggmp24` for consistency [#22]
+
+[#22]: https://github.com/dfns/trusted-dealer/pull/22
+
 ## v0.3.0
 * Add support of HD wallets [#21]
 

--- a/key-import/Cargo.toml
+++ b/key-import/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfns-key-import"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 serde_json = "1"
 
-common = { package = "dfns-trusted-dealer-common", version = "0.3", path = "../common", features = ["import"] }
+common = { package = "dfns-trusted-dealer-common", version = "0.4", path = "../common", features = ["import"] }
 
 generic-ec-zkp = { version = "0.4", default-features = false, features = ["serde", "alloc"] }
 sha2 = { version = "0.10", default-features = false }

--- a/key-import/src/lib.rs
+++ b/key-import/src/lib.rs
@@ -130,7 +130,7 @@ pub fn build_key_import_request(
         .map_err(|_| Error::new("chain code has invalid length"))?;
 
     match (protocol, curve) {
-        (KeyProtocol::Cggmp21, KeyCurve::Secp256k1)
+        (KeyProtocol::Cggmp24, KeyCurve::Secp256k1)
         | (KeyProtocol::FrostBitcoin, KeyCurve::Secp256k1) => {
             build_key_import_request_for_curve::<curves::Secp256k1>(
                 &mut rng,
@@ -143,7 +143,7 @@ pub fn build_key_import_request(
                 n,
             )
         }
-        (KeyProtocol::Cggmp21, KeyCurve::Stark) => {
+        (KeyProtocol::Cggmp24, KeyCurve::Stark) => {
             build_key_import_request_for_curve::<curves::Stark>(
                 &mut rng,
                 protocol,

--- a/key-import/tests/tests.rs
+++ b/key-import/tests/tests.rs
@@ -8,10 +8,10 @@ use dfns_key_import::{KeyCurve, KeyProtocol};
 use key_share::Validate;
 use rand::Rng;
 
-#[test_case::case(KeyProtocol::Cggmp21, KeyCurve::Secp256k1, 3, 5; "cggmp21_secp256k1_t3n5")]
-#[test_case::case(KeyProtocol::Cggmp21, KeyCurve::Secp256k1, 2, 3; "cggmp21_secp256k1_t2n3")]
-#[test_case::case(KeyProtocol::Cggmp21, KeyCurve::Stark, 3, 5; "cggmp21_stark_t3n5")]
-#[test_case::case(KeyProtocol::Cggmp21, KeyCurve::Stark, 2, 3; "cggmp21_stark_t2n3")]
+#[test_case::case(KeyProtocol::Cggmp24, KeyCurve::Secp256k1, 3, 5; "cggmp21_secp256k1_t3n5")]
+#[test_case::case(KeyProtocol::Cggmp24, KeyCurve::Secp256k1, 2, 3; "cggmp21_secp256k1_t2n3")]
+#[test_case::case(KeyProtocol::Cggmp24, KeyCurve::Stark, 3, 5; "cggmp21_stark_t3n5")]
+#[test_case::case(KeyProtocol::Cggmp24, KeyCurve::Stark, 2, 3; "cggmp21_stark_t2n3")]
 #[test_case::case(KeyProtocol::Frost, KeyCurve::Ed25519, 3, 5; "frost_ed25519_t3n5")]
 #[test_case::case(KeyProtocol::Frost, KeyCurve::Ed25519, 2, 3; "frost_ed25519_t2n3")]
 fn key_import(protocol: KeyProtocol, curve: KeyCurve, t: u16, n: u16) {


### PR DESCRIPTION
New version passes tests in signers, see https://github.com/dfnsco/signers/pull/189