### PR TITLE
Update deps, bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "dfns-key-export"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.21.7",
  "dfns-trusted-dealer-common",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "dfns-key-import"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "dfns-trusted-dealer-common",
  "ed25519-dalek",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "dfns-trusted-dealer-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "base64 0.21.7",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "generic-ec"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de1099ac0b4d87261d67ff5d4ed400af617a1da40b58908d759b9cf5fd8ed27"
+checksum = "6d693ffb53818f267a4c20e06f161aee3569a4ebaec5b9105d2fd7490b79fb53"
 dependencies = [
  "curve25519-dalek",
  "generic-ec-core",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-core"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcba5fdf70cc3ce5805c487f8523b4ceeb32e8ec5237c71ffd93c1ca47a97fee"
+checksum = "ffea0573b3bdde9a0bbbf17433b19f9628942e075d723702c2f495f0a2f65268"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-curves"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7c6d23001a5eb60eec2b785a63d2ca965fdfbaf3314b3b46df047398369e28"
+checksum = "ffbc925fd3e3679dc46eb028029be23f3eb215f9392847d10223d853a459ab3c"
 dependencies = [
  "curve25519-dalek",
  "elliptic-curve",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-zkp"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3945c585fdddba3f86bda4e4cfba22d5e255001b3e145c9db305ad096c6d88"
+checksum = "b19b88bd3d9b24d30d21ee91c0feb9480e4fec008a1b8b9bf2c16e0afbf43a2e"
 dependencies = [
  "generic-array",
  "generic-ec",
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "key-share"
-version = "0.4.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f32a511457947ec927d7372e71f5bf41476613a50456174d3597e4c1a40e1e"
+checksum = "4c6ef14aa29a4d7cac8026894c16821e6dee20bfa8c8f7bb9d2820e05e756652"
 dependencies = [
  "displaydoc",
  "generic-ec",

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.5.0
+* Update `generic-ec` to v0.5 [#24]
+
+[#24]: https://github.com/dfns/trusted-dealer/pull/24
+
 ## v0.4.0
 * Rename `types::KeyProtocol::Cggmp21` to `Cggmp24` for consistency [#22]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "dfns-trusted-dealer-common"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 
 [dependencies]
-generic-ec = { version = "0.4", default-features = false, features = ["serde", "curve-secp256k1", "curve-stark", "curve-ed25519"] }
+generic-ec = { version = "0.5", default-features = false, features = ["serde", "curve-secp256k1", "curve-stark", "curve-ed25519"] }
 
 rand_core = { version = "0.6", default-features = false }
 

--- a/key-export/CHANGELOG.md
+++ b/key-export/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.5.0
+* Update `generic-ec` to v0.5 [#24]
+
+[#24]: https://github.com/dfns/trusted-dealer/pull/24
+
 ## v0.4.0
 * Rename `KeyProtocol::Cggmp21` to `Cggmp24` for consistency [#22]
 

--- a/key-export/Cargo.toml
+++ b/key-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfns-key-export"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 
@@ -12,9 +12,9 @@ description = "Cryptography code for exporting a key from Dfns"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-common = { package = "dfns-trusted-dealer-common", version = "0.4", path = "../common", features = ["export"] }
-generic-ec = { version = "0.4", default-features = false, features = ["serde", "curve-secp256k1", "curve-stark", "curve-ed25519"] }
-generic-ec-zkp = { version = "0.4", default-features = false, features = ["serde", "alloc"] }
+common = { package = "dfns-trusted-dealer-common", version = "0.5", path = "../common", features = ["export"] }
+generic-ec = { version = "0.5", default-features = false, features = ["serde", "curve-secp256k1", "curve-stark", "curve-ed25519"] }
+generic-ec-zkp = { version = "0.5", default-features = false, features = ["serde", "alloc"] }
 zeroize = { version = "1.7", default-features = false, features = ["alloc"]}
 
 serde_json = "1"
@@ -29,4 +29,4 @@ rand = "0.8"
 rand_dev = "0.1"
 generic-tests = "0.1"
 test-case = "3" 
-key-share = { version = "0.4", features = ["spof"] }
+key-share = { version = "0.7", features = ["spof"] }

--- a/key-export/src/lib.rs
+++ b/key-export/src/lib.rs
@@ -204,8 +204,8 @@ impl KeyExportContext {
             (protocol, curve) => {
                 return Err(Error::new(&alloc::format!(
                     "protocol {:?} using curve {:?} is not supported for key export",
-                    &protocol,
-                    &curve
+                    protocol,
+                    curve
                 )));
             }
         };

--- a/key-import/CHANGELOG.md
+++ b/key-import/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.5.0
+* Update `generic-ec` to v0.5 [#24]
+
+[#24]: https://github.com/dfns/trusted-dealer/pull/24
+
 ## v0.4.0
 * Rename `KeyProtocol::Cggmp21` to `Cggmp24` for consistency [#22]
 

--- a/key-import/Cargo.toml
+++ b/key-import/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfns-key-import"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 
@@ -14,9 +14,9 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 serde_json = "1"
 
-common = { package = "dfns-trusted-dealer-common", version = "0.4", path = "../common", features = ["import"] }
+common = { package = "dfns-trusted-dealer-common", version = "0.5", path = "../common", features = ["import"] }
 
-generic-ec-zkp = { version = "0.4", default-features = false, features = ["serde", "alloc"] }
+generic-ec-zkp = { version = "0.5", default-features = false, features = ["serde", "alloc"] }
 sha2 = { version = "0.10", default-features = false }
 
 zeroize = { version = "1.7", default-features = false, features = ["alloc"]}
@@ -28,6 +28,6 @@ getrandom = { version = "0.2", features = ["js"] }
 rand = "0.8"
 rand_dev = "0.1"
 test-case = "3" 
-key-share = { version = "0.4", features = ["spof"] }
+key-share = { version = "0.7", features = ["spof"] }
 
 ed25519 = { package = "ed25519-dalek", version = "2", default-features = false, features = ["hazmat"] }

--- a/key-import/src/lib.rs
+++ b/key-import/src/lib.rs
@@ -169,8 +169,8 @@ pub fn build_key_import_request(
         }
         (p, c) => Err(Error::new(&alloc::format!(
             "protocol {:?} using curve {:?} is not supported for key import",
-            &p,
-            &c
+            p,
+            c
         ))),
     }
 }


### PR DESCRIPTION
## Changes

- Bump `dfns-trusted-dealer-common`, `dfns-key-export`, `dfns-key-import` to `v0.5.0`
- Update `generic-ec` from `v0.4` to `v0.5`
- Update `generic-ec-zkp` from `v0.4` to `v0.5`
- Update `key-share` from `v0.4` to `v0.7` (dev-dependencies)